### PR TITLE
endpoints w/ OpenAPI standart

### DIFF
--- a/AddressValidation.yaml
+++ b/AddressValidation.yaml
@@ -4,9 +4,9 @@ info:
   termsOfService: https://www.ups.com/upsdeveloperkit/assets/html/serviceAgreement.html
   version: ''
 servers:
-- url: https://wwwcie.ups.com/api/
+- url: https://wwwcie.ups.com/api
   description: Customer Integration Environment
-- url: https://onlinetools.ups.com/api/
+- url: https://onlinetools.ups.com/api
   description: Production
 tags:
   - name: AddressValidation_other

--- a/DangerousGoods.yaml
+++ b/DangerousGoods.yaml
@@ -4,9 +4,9 @@ info:
   termsOfService: https://www.ups.com/upsdeveloperkit/assets/html/serviceAgreement.html
   version: ''
 servers:
-- url: https://wwwcie.ups.com/api/
+- url: https://wwwcie.ups.com/api
   description: Customer Integration Environment
-- url: https://onlinetools.ups.com/api/
+- url: https://onlinetools.ups.com/api
   description: Production
 tags:
 - name: DangerousGoods_other

--- a/LandedCost.yaml
+++ b/LandedCost.yaml
@@ -12,9 +12,9 @@ info:
   termsOfService: https://www.ups.com/upsdeveloperkit/assets/html/serviceAgreement.html
   version: ''
 servers:
-- url: https://wwwcie.ups.com/api/
+- url: https://wwwcie.ups.com/api
   description: Customer Integration Environment
-- url: https://onlinetools.ups.com/api/
+- url: https://onlinetools.ups.com/api
   description: Production
 tags:
 - name: LandedCost_other

--- a/Locator.yaml
+++ b/Locator.yaml
@@ -4,9 +4,9 @@ info:
   termsOfService: https://www.ups.com/upsdeveloperkit/assets/html/serviceAgreement.html
   version: ''
 servers:
-- url: https://wwwcie.ups.com/api/
+- url: https://wwwcie.ups.com/api
   description: Customer Integration Environment
-- url: https://onlinetools.ups.com/api/
+- url: https://onlinetools.ups.com/api
   description: Production
 tags:
 - name: Locator_other

--- a/OAuthAuthCode.yaml
+++ b/OAuthAuthCode.yaml
@@ -20,9 +20,9 @@ info:
     - <a href="https://github.com/UPS-API" target="_blank" rel="noopener noreferrer">Sample integration code on GitHub</a>
   version: '1.0'
 servers:
-- url: https://wwwcie.ups.com/
+- url: https://wwwcie.ups.com
   description: Customer Integration Environment
-- url: https://onlinetools.ups.com/
+- url: https://onlinetools.ups.com
   description: Production
 tags:
 - name: OAuthAuthCode_other

--- a/OAuthClientCredentials.yaml
+++ b/OAuthClientCredentials.yaml
@@ -3,9 +3,9 @@ info:
   title: OAuth Client Credentials API
   version: ''
 servers:
-- url: https://wwwcie.ups.com/
+- url: https://wwwcie.ups.com
   description: Customer Integration Environment for Client Credentials
-- url: https://onlinetools.ups.com/
+- url: https://onlinetools.ups.com
   description: Production for Client Credentials
 tags:
 - name: OAuthClientCredentials_other

--- a/Paperless.yaml
+++ b/Paperless.yaml
@@ -4,9 +4,9 @@ info:
   termsOfService: https://www.ups.com/upsdeveloperkit/assets/html/serviceAgreement.html
   version: ''
 servers:
-- url: https://wwwcie.ups.com/api/
+- url: https://wwwcie.ups.com/api
   description: Customer Integration Environment
-- url: https://onlinetools.ups.com/api/
+- url: https://onlinetools.ups.com/api
   description: Production
 tags:
 - name: Paperless_other

--- a/Pickup.yaml
+++ b/Pickup.yaml
@@ -4,9 +4,9 @@ info:
   termsOfService: https://www.ups.com/upsdeveloperkit/assets/html/serviceAgreement.html
   version: ''
 servers:
-- url: https://wwwcie.ups.com/api/
+- url: https://wwwcie.ups.com/api
   description: Customer Integration Environment
-- url: https://onlinetools.ups.com/api/
+- url: https://onlinetools.ups.com/api
   description: Production
 tags:
 - name: Pickup_other

--- a/PreNotification.yaml
+++ b/PreNotification.yaml
@@ -4,9 +4,9 @@ info:
   termsOfService: https://www.ups.com/upsdeveloperkit/assets/html/serviceAgreement.html
   version: ''
 servers:
-- url: https://wwwcie.ups.com/api/
+- url: https://wwwcie.ups.com/api
   description: Customer Integration Environment
-- url: https://onlinetools.ups.com/api/
+- url: https://onlinetools.ups.com/api
   description: Production
 tags:
 - name: PreNotification_other

--- a/QuantumView.yaml
+++ b/QuantumView.yaml
@@ -4,9 +4,9 @@ info:
   termsOfService: https://www.ups.com/upsdeveloperkit/assets/html/serviceAgreement.html
   version: ''
 servers:
-- url: https://wwwcie.ups.com/api/
+- url: https://wwwcie.ups.com/api
   description: Customer Integration Environment
-- url: https://onlinetools.ups.com/api/
+- url: https://onlinetools.ups.com/api
   description: Production
 tags:
 - name: QuantumView_other

--- a/Rating.yaml
+++ b/Rating.yaml
@@ -4,9 +4,9 @@ info:
   termsOfService: https://www.ups.com/upsdeveloperkit/assets/html/serviceAgreement.html
   version: ''
 servers:
-- url: https://wwwcie.ups.com/api/
+- url: https://wwwcie.ups.com/api
   description: Customer Integration Environment
-- url: https://onlinetools.ups.com/api/
+- url: https://onlinetools.ups.com/api
   description: Production
 tags:
 - name: Rating_other

--- a/Shipping.yaml
+++ b/Shipping.yaml
@@ -4,9 +4,9 @@ info:
   termsOfService: https://www.ups.com/upsdeveloperkit/assets/html/serviceAgreement.html
   version: ''
 servers:
-- url: https://wwwcie.ups.com/api/
+- url: https://wwwcie.ups.com/api
   description: Customer Integration Environment
-- url: https://onlinetools.ups.com/api/
+- url: https://onlinetools.ups.com/api
   description: Production
 tags:
 - name: Shipping_other

--- a/TimeInTransit.yaml
+++ b/TimeInTransit.yaml
@@ -10,9 +10,9 @@ info:
   termsOfService: https://www.ups.com/upsdeveloperkit/assets/html/serviceAgreement.html
   version: ''
 servers:
-- url: https://wwwcie.ups.com/api/
+- url: https://wwwcie.ups.com/api
   description: Customer Integration Environment
-- url: https://onlinetools.ups.com/api/
+- url: https://onlinetools.ups.com/api
   description: Production
 tags:
 - name: TimeInTransit_other

--- a/Tracking.yaml
+++ b/Tracking.yaml
@@ -4,9 +4,9 @@ info:
   termsOfService: https://www.ups.com/upsdeveloperkit/assets/html/serviceAgreement.html
   version: ''
 servers:
-- url: https://wwwcie.ups.com/api/
+- url: https://wwwcie.ups.com/api
   description: Customer Integration Environment
-- url: https://onlinetools.ups.com/api/
+- url: https://onlinetools.ups.com/api
   description: Production
 tags:
 - name: Tracking_other


### PR DESCRIPTION
relative server-url makes more sense cause paths are absolute

ref. https://spec.openapis.org/oas/v3.0.3#server-object
ref. https://spec.openapis.org/oas/v3.0.3#paths-object