### PR TITLE
Locator API: OpenHours and ClosedHours are sometimes arrays

### DIFF
--- a/Locator.yaml
+++ b/Locator.yaml
@@ -2122,17 +2122,29 @@ components:
             1700, 1845 etc. with exception for midnight. For midnight the time will
             be returned as 0.
           maximum: 1
-          type: string
-          minLength: 4
-          maxLength: 4
+          oneOf:
+            - type: string
+              minLength: 4
+              maxLength: 4
+            - type: array
+              items:
+                  type: string
+                  minLength: 4
+                  maxLength: 4
         CloseHours:
           description: Close time of a location in military format (HHMM) e.g. 930,
             1700, 1845 etc. with exception for midnight. For midnight the time will
             be returned as 0.
           maximum: 1
-          type: string
-          minLength: 4
-          maxLength: 4
+          oneOf:
+            - type: string
+              minLength: 4
+              maxLength: 4
+            - type: array
+              items:
+                type: string
+                minLength: 4
+                maxLength: 4
         LatestDropOffHours:
           description: LatestDropOffHours for Hour Type 50. Latest Drop Off time of
             a location in military format (HHMM) e.g. 930, 1700, 1845 etc. with exception


### PR DESCRIPTION
An example of this:

```
{
  "LocationID": "157095",
  "IVR": {
    "PhraseID": "0"
  },
  "Geocode": {
    "Latitude": "52.29183959",
    "Longitude": "4.701498985"
  },
  "AddressKeyFormat": {
    "ConsigneeName": "NOVOTEL AMSTERDAM SCHIPHOL AIRPORT",
    "AddressLine": "TAURUSAVENUE 12",
    "PoliticalDivision2": "HOOFDDORP",
    "PostcodePrimaryLow": "2132LS",
    "CountryCode": "NL"
  },
  "Distance": {
    "Value": "0.7",
    "UnitOfMeasurement": {
      "Code": "KM",
      "Description": "KILOMETERS"
    }
  },
  "SpecialInstructions": {
    "Segment": "Het nieuwe Novotel Hotel"
  },
  "AdditionalChargeIndicator": "",
  "StandardHoursOfOperation": "Mon-Sun: 7:00am-5:00pm, 6:00pm-10:00pm",
  "OperatingHours": {
    "StandardHours": [
      {
        "HoursType": "10",
        "DayOfWeek": [
          {
            "Day": "1",
            "OpenHours": [
              "700",
              "1800"
            ],
            "CloseHours": [
              "1700",
              "2200"
            ]
          },
          {
            "Day": "2",
            "OpenHours": [
              "700",
              "1800"
            ],
            "CloseHours": [
              "1700",
              "2200"
            ]
          },
...
```