### PR TITLE
Indicate format of POD string

### DIFF
--- a/Tracking.yaml
+++ b/Tracking.yaml
@@ -362,7 +362,7 @@ components:
            properties:
             content:
               type: string
-              description: 'The base64 encoded string representation of the Delivery Proof. Note: This is considered sensitive data and may only be returned for a user that has rights to the package.'
+              description: 'The base64 encoded string representation of the Delivery Proof in HTML format. Note: This is considered sensitive data and may only be returned for a user that has rights to the package.'
     DeliveryPhoto:
       title: DeliveryPhoto
       type: object


### PR DESCRIPTION
We assumed the base64 string would be a PDF representation of the POD, but saw that instead it is in HTML format. This clarification will aid in such a situation.